### PR TITLE
Fix runtime error "index out of range"

### DIFF
--- a/pkg/hugo/frontmatter.go
+++ b/pkg/hugo/frontmatter.go
@@ -134,5 +134,9 @@ func getAllStringItems(cfm *pageparser.ContentFrontMatter, fmKey string) ([]stri
 
 func getFirstStringItem(cfm *pageparser.ContentFrontMatter, fmKey string) (string, error) {
 	arr, err := getAllStringItems(cfm, fmKey)
-	return arr[0], err
+	if err != nil {
+		return "", err
+	}
+
+	return arr[0], nil
 }


### PR DESCRIPTION
If authors or categories in frontmatter are empty, then length of the
return value of getFirstString function will be zero. This occurs "index
out of range" runtime error.

```
$ tcardgen -f hack/card/font -t hack/card/template.png content/test.md
Load fonts from "hack/card/font"
Load template from "hack/card/template.png" directory
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/Ladicle/tcardgen/pkg/hugo.getFirstStringItem(...)
        /Users/ksuda/src/github.com/Ladicle/tcardgen/pkg/hugo/frontmatter.go:137
github.com/Ladicle/tcardgen/pkg/hugo.ParseFrontMatter(0x7ffeefbfefd5, 0x1f, 0x0, 0x0, 0x0)
        /Users/ksuda/src/github.com/Ladicle/tcardgen/pkg/hugo/frontmatter.go:50 +0x53a
github.com/Ladicle/tcardgen/cmd.generateTCard(0x7ffeefbfefd5, 0x1f, 0xc000024380, 0x1c, 0x15bff40, 0xc000090080, 0xc0000c5900, 0xc0000fdcd0, 0x0, 0x0)
        /Users/ksuda/src/github.com/Ladicle/tcardgen/cmd/cmd.go:143 +0x50
github.com/Ladicle/tcardgen/cmd.(*RootCommandOption).Run(0xc0000cf4a0, 0x15b7360, 0xc0000cc008, 0x15b7360, 0xc0000cc010, 0x11d2120, 0xc0000fdd48)
        /Users/ksuda/src/github.com/Ladicle/tcardgen/cmd/cmd.go:128 +0x4b6
github.com/Ladicle/tcardgen/cmd.NewRootCmd.func1(0xc0001a4500, 0xc0000d31e0, 0x11, 0x15, 0x0, 0x0)
        /Users/ksuda/src/github.com/Ladicle/tcardgen/cmd/cmd.go:75 +0xa7
github.com/spf13/cobra.(*Command).execute(0xc0001a4500, 0xc0000d2010, 0x15, 0x15, 0xc0001a4500, 0xc0000d2010)
        /Users/ksuda/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001a4500, 0x0, 0x0, 0x0)
        /Users/ksuda/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/ksuda/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /Users/ksuda/src/github.com/Ladicle/tcardgen/main.go:17 +0x27
```

`content/test.md`:
```markdown
---
title: "My First Post"
date: 2019-03-24T00:22:11Z
draft: false
tags: ["hugo", "hugo theme", "netlify"]
---

Hello world
```