### PR TITLE
Add feature to specify output file's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ Generate TwitterCard(OGP) images for your Hugo posts.
 Supported front-matters are title, author, categories, tags, and date.
 
 Usage:
-  tcardgen [-f <FONTDIR>] [-o <OUTDIR>] [-t <TEMPLATE>] [-c <CONFIG>] <FILE>...
+  tcardgen [-f <FONTDIR>] [-o <OUTPUT>] [-t <TEMPLATE>] [-c <CONFIG>] <FILE>...
 
 Examples:
 # Generate a image and output to the example directory.
-tcardgen --fontDir=font --outDir=example --template=example/template.png example/blog-post.md
+tcardgen --fontDir=font --output=example --template=example/template.png example/blog-post.md
+
+# Generate a image and output to the example directory as "featured.png".
+tcardgen --fontDir=font --output=example/featured.png --template=example/template.png example/blog-post.md
 
 # Generate multiple images.
 tcardgen --template=example/template.png example/*.md
@@ -106,6 +109,7 @@ Flags:
   -c, --config string     Set a drawing configuration file.
   -f, --fontDir string    Set a font directory. (default "font")
   -h, --help              help for tcardgen
-  -o, --outDir string     Set an output directory. (default "out")
+      --outDir string     (DEPRECATED) Set an output directory.
+  -o, --output string     Set an output directory or filename (only png format). (default "out")
   -t, --template string   Set a template image file. (default example/template.png)
 ```

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -88,6 +88,12 @@ func (o *RootCommandOption) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("required argument <FILE> is not set")
 	}
+
+	isSpecifiedOutputFilename := strings.HasSuffix(o.output, ".png")
+	if isSpecifiedOutputFilename && len(args) > 1 {
+		return errors.New("cannot accept multiple <FILE>s when you specify output filename")
+	}
+
 	o.files = args
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	defaultFontDir = "font"
-	defaultOutDir  = "out"
 
 	longDesc = `Generate TwitterCard(OGP) images for your Hugo posts.
 Supported front-matters are title, author, categories, tags, and date.`
@@ -76,7 +75,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&opt.fontDir, "fontDir", "f", defaultFontDir, "Set a font directory.")
-	cmd.Flags().StringVarP(&opt.outDir, "outDir", "o", defaultOutDir, "Set an output directory.")
+	cmd.Flags().StringVarP(&opt.outDir, "outDir", "o", "", "(DEPRECATED) Set an output directory.")
 	cmd.Flags().StringVarP(&opt.tplImg, "template", "t", "", fmt.Sprintf("Set a template image file. (default %s)", config.DefaultTemplate))
 	cmd.Flags().StringVarP(&opt.config, "config", "c", "", "Set a drawing configuration file.")
 	return cmd
@@ -112,10 +111,14 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 	}
 	fmt.Fprintf(streams.Out, "Load template from %q directory\n", cnf.Template)
 
-	if _, err := os.Stat(o.outDir); os.IsNotExist(err) {
-		err := os.Mkdir(o.outDir, 0755)
-		if err != nil {
-			return err
+	if o.outDir != "" {
+		fmt.Fprint(streams.Out, "\nWarning: This flag will be removed in the future. Please use \"--output\".\n\n")
+
+		if _, err := os.Stat(o.outDir); os.IsNotExist(err) {
+			err := os.Mkdir(o.outDir, 0755)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	defaultFontDir = "font"
+	defaultOutput  = "out"
 
 	longDesc = `Generate TwitterCard(OGP) images for your Hugo posts.
 Supported front-matters are title, author, categories, tags, and date.`
@@ -48,6 +49,7 @@ type RootCommandOption struct {
 	files   []string
 	fontDir string
 	outDir  string
+	output  string
 	tplImg  string
 	config  string
 }
@@ -55,7 +57,7 @@ type RootCommandOption struct {
 func NewRootCmd() *cobra.Command {
 	opt := RootCommandOption{}
 	cmd := &cobra.Command{
-		Use:                   "tcardgen [-f <FONTDIR>] [-o <OUTDIR>] [-t <TEMPLATE>] [-c <CONFIG>] <FILE>...",
+		Use:                   "tcardgen [-f <FONTDIR>] [-o <OUTPUT>] [-t <TEMPLATE>] [-c <CONFIG>] <FILE>...",
 		Version:               version,
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
@@ -75,7 +77,8 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&opt.fontDir, "fontDir", "f", defaultFontDir, "Set a font directory.")
-	cmd.Flags().StringVarP(&opt.outDir, "outDir", "o", "", "(DEPRECATED) Set an output directory.")
+	cmd.Flags().StringVarP(&opt.outDir, "outDir", "", "", "(DEPRECATED) Set an output directory.")
+	cmd.Flags().StringVarP(&opt.output, "output", "o", defaultOutput, "Set an output directory or filename (only png format).")
 	cmd.Flags().StringVarP(&opt.tplImg, "template", "t", "", fmt.Sprintf("Set a template image file. (default %s)", config.DefaultTemplate))
 	cmd.Flags().StringVarP(&opt.config, "config", "c", "", "Set a drawing configuration file.")
 	return cmd

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,9 @@ var (
 	command string
 	version string
 	commit  string
+
+	// isSpecifiedOutputFilename is true when user specify the output file's name
+	isSpecifiedOutputFilename bool
 )
 
 type IOStreams struct {
@@ -92,7 +95,7 @@ func (o *RootCommandOption) Validate(cmd *cobra.Command, args []string) error {
 		return errors.New("required argument <FILE> is not set")
 	}
 
-	isSpecifiedOutputFilename := strings.HasSuffix(o.output, ".png")
+	isSpecifiedOutputFilename = strings.HasSuffix(o.output, ".png")
 	if isSpecifiedOutputFilename && len(args) > 1 {
 		return errors.New("cannot accept multiple <FILE>s when you specify output filename")
 	}
@@ -125,7 +128,6 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 
 	outDir := defaultOutput
 	outFilename := ""
-	isSpecifiedOutputFilename := strings.HasSuffix(o.output, ".png")
 
 	if o.output != defaultOutput {
 		outDir = o.output

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,7 +24,10 @@ const (
 	longDesc = `Generate TwitterCard(OGP) images for your Hugo posts.
 Supported front-matters are title, author, categories, tags, and date.`
 	example = `# Generate a image and output to the example directory.
-tcardgen --fontDir=font --outDir=example --template=example/template.png example/blog-post.md
+tcardgen --fontDir=font --output=example --template=example/template.png example/blog-post.md
+
+# Generate a image and output to the example directory as "featured.png".
+tcardgen --fontDir=font --output=example/featured.png --template=example/template.png example/blog-post.md
 
 # Generate multiple images.
 tcardgen --template=example/template.png example/*.md

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,7 +42,7 @@ var (
 	version string
 	commit  string
 
-	// isSpecifiedOutputFilename is true when user specify the output file's name
+	// isSpecifiedOutputFilename is true when the user specifies the name of the output file
 	isSpecifiedOutputFilename bool
 )
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -148,8 +148,8 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 
 	var errCnt int
 	for _, f := range o.files {
-		base := filepath.Base(f)
 		if !isSpecifiedOutputFilename {
+			base := filepath.Base(f)
 			outFilename = base[:len(base)-len(filepath.Ext(base))] + ".png"
 		}
 		out := filepath.Join(outDir, outFilename)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -132,9 +132,7 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 	if o.output != defaultOutput {
 		outDir = o.output
 		if isSpecifiedOutputFilename {
-			splitOutput := strings.Split(o.output, "/")
-			outFilename = splitOutput[len(splitOutput)-1]
-			outDir = o.output[0 : len(o.output)-len(outFilename)]
+			outDir, outFilename = filepath.Split(o.output)
 		}
 	} else if o.outDir != "" {
 		fmt.Fprint(streams.Out, "\nWarning: This flag will be removed in the future. Please use \"--output\".\n\n")


### PR DESCRIPTION
# Overview

This PR resolves issue https://github.com/Ladicle/tcardgen/issues/6.

I added the feature to specify output file's name.

# Changes

- Add `output` flag
- `outDir` flag is deprecated

# Tests

- [x] Generate the image using `--outDir`
  - [x] Show warning
  - [x] Accept both single file and multiple files
- [x] Generate the image using `--output` (`-o`)
  - [x] Specify directory as output destination.
    - [x] Accept single file
    - [x] Accept multiple files
  - [x] Specify filename as output destination.
    - [x] Accept single file
    - [x] Can't accept multiple files
- [x] `--output` takes priority over `--outDir`
- [x] Show help
  - [x] `--outDir`'s deprecated message
  - [x] `output`'s message