### PR TITLE
make name/date separator configurable

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -196,7 +196,7 @@ func generateTCard(contentPath, outPath string, tpl image.Image, ffa *fontfamily
 		return err
 	}
 	if err := c.DrawTextAtPoint(
-		fmt.Sprintf("%s・%s", fm.Author, fm.Date.Format("Jan 2")),
+		fmt.Sprintf("%s%s%s", fm.Author, cnf.Info.Separator, fm.Date.Format("Jan 2")),
 		*cnf.Info.Start,
 		canvas.FgHexColor(cnf.Info.FgHexColor),
 		canvas.FontFaceFromFFA(ffa, cnf.Info.FontStyle, cnf.Info.FontSize),

--- a/example/template3.config.yaml
+++ b/example/template3.config.yaml
@@ -22,6 +22,7 @@ info:
   fgHexColor: "#A0A0A0"
   fontSize: 38
   fontStyle: Regular
+  separator: " - "
 tags:
   start:
     px: 120

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type TextOption struct {
 	FgHexColor string           `json:"fgHexColor,omitempty"`
 	FontSize   float64          `json:"fontSize,omitempty"`
 	FontStyle  fontfamily.Style `json:"fontStyle,omitempty"`
+	Separator  string           `json:"separator,omitempty"`
 }
 
 type MultiLineTextOption struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -29,6 +29,7 @@ var defaultCnf = DrawingConfig{
 		FgHexColor: "#8D8D8D",
 		FontSize:   38,
 		FontStyle:  fontfamily.Regular,
+		Separator:  "・",
 	},
 	Tags: &BoxTextsOption{
 		TextOption: TextOption{
@@ -123,6 +124,9 @@ func setArgsAsDefaultTextOption(to *TextOption, dto *TextOption) {
 	}
 	if to.FontStyle == "" {
 		to.FontStyle = dto.FontStyle
+	}
+	if to.Separator == "" {
+		to.Separator = dto.Separator
 	}
 }
 


### PR DESCRIPTION
The font I wanted to use doesn't include the "・" character, so the resulting image had
a unicode error ? thing instead. This PR keeps the "・" as the default but lets the
user configure a different separator if they want. (It also adds that to the sample
config so users can know the option is there.)
