### PR TITLE
Add the installation guide for go1.16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,16 @@ Also, both toml and yaml formats are supported.
 
 ## Installation
 
+### Go version < 1.16
+
 ```bash
-go get github.com/Ladicle/tcardgen
+go get github.com/Ladicle/tcardgen@latest
+```
+
+### Go 1.16+
+
+```bash
+go install github.com/Ladicle/tcardgen@latest
 ```
 
 ## Getting Started


### PR DESCRIPTION
In go1.18, the installation with `go get` is no longer working.
This PR adds the installation way with `go install`.

```
$ go version
go version go1.18.3 darwin/arm64
$ go get github.com/Ladicle/tcardgen
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```