### PR TITLE
feat: when date, lastmod, publishDate are not set, use now as default

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -76,7 +77,7 @@ func NewRootCmd() *cobra.Command {
 			if err := opt.Validate(cmd, args); err != nil {
 				return err
 			}
-			return opt.Run(streams)
+			return opt.Run(streams, time.Now())
 		},
 	}
 	cmd.Flags().StringVarP(&opt.fontDir, "fontDir", "f", defaultFontDir, "Set a font directory.")
@@ -104,7 +105,7 @@ func (o *RootCommandOption) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *RootCommandOption) Run(streams IOStreams) error {
+func (o *RootCommandOption) Run(streams IOStreams, currentTime time.Time) error {
 	ffa, err := fontfamily.LoadFromDir(o.fontDir)
 	if err != nil {
 		return err
@@ -147,7 +148,7 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 			out += fmt.Sprintf("/%s.png", base[:len(base)-len(filepath.Ext(base))])
 		}
 
-		if err := generateTCard(f, out, tpl, ffa, cnf); err != nil {
+		if err := generateTCard(streams, f, out, tpl, ffa, cnf, currentTime); err != nil {
 			fmt.Fprintf(streams.ErrOut, "Failed to generate twitter card for %v: %v\n", out, err)
 			errCnt++
 			continue
@@ -161,8 +162,8 @@ func (o *RootCommandOption) Run(streams IOStreams) error {
 	return nil
 }
 
-func generateTCard(contentPath, outPath string, tpl image.Image, ffa *fontfamily.FontFamily, cnf *config.DrawingConfig) error {
-	fm, err := hugo.ParseFrontMatter(contentPath)
+func generateTCard(streams IOStreams, contentPath, outPath string, tpl image.Image, ffa *fontfamily.FontFamily, cnf *config.DrawingConfig, currentTime time.Time) error {
+	fm, err := hugo.ParseFrontMatter(streams.Out, contentPath, currentTime)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gohugoio/hugo v0.88.1
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5

--- a/pkg/hugo/frontmatter_test.go
+++ b/pkg/hugo/frontmatter_test.go
@@ -2,6 +2,7 @@ package hugo
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,6 +10,8 @@ import (
 )
 
 func TestParseFrontMatterFromReader(t *testing.T) {
+	currentTime := time.Now()
+
 	testCases := []struct {
 		desc      string
 		input     string
@@ -102,20 +105,27 @@ categories = ["Program"]
 			expectErr: NewFMNotExistError(fmTags),
 		},
 		{
-			desc: "Time is missing",
+			desc: "When time is missing, default time is now",
 			input: `+++
 title = "Title"
 author = ["@Ladicle"]
 categories = ["cat11"]
 tags = ["tag1"]
 +++`,
-			expectErr: errors.New("\"date, lastmod, publishDate\" is not defined or empty"),
+			expectFM: &FrontMatter{
+				Title:    "Title",
+				Author:   "@Ladicle",
+				Category: "cat11",
+				Tags:     []string{"tag1"},
+				Date:     currentTime,
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			r := strings.NewReader(tc.input)
-			fm, err := parseFrontMatter(r)
+			w := os.Stdout
+			fm, err := parseFrontMatter(w, r, currentTime)
 			if err != nil {
 				if tc.expectErr != nil {
 					if tc.expectErr.Error() == err.Error() {


### PR DESCRIPTION
## Overview

When there is no date field in front matter, the image cannot be generated with the following error.

```
Failed to generate twitter card for static/ogp/hoge.png: "date, lastmod, publishDate" is not defined or empty
```

Also, if you have the following configuration in config.yml of hugo, you can omit the field of front matter.

```yml
enableGitInfo: true
frontmatter:
  date:
    - date
    - lastmod
    - :git
  lastmod:
    - :git
```

Here, if there are no field (date, lastmod, publishDate), we responded to put in the execute date by default.

## Changes

- Fixed to pass execution time as an argument.
- Fixed to pass io.Writer as an argument.
- If there are  no field (date, lastmod, publishDate), a warn message is output and the error is not returned.

## Test

 - Unit Test

```
go test ./...
?       github.com/Ladicle/tcardgen     [no test files]
?       github.com/Ladicle/tcardgen/cmd [no test files]
?       github.com/Ladicle/tcardgen/pkg/canvas  [no test files]
?       github.com/Ladicle/tcardgen/pkg/canvas/box      [no test files]
?       github.com/Ladicle/tcardgen/pkg/canvas/fontfamily       [no test files]
?       github.com/Ladicle/tcardgen/pkg/config  [no test files]
ok      github.com/Ladicle/tcardgen/pkg/hugo    0.297s
```

- Generate Image

```
./tcardgen \
    --fontDir static/fonts/kinto \
    --output static/ogp \
    --template static/ogp/hoge.png \
    content/hoge.md
Load fonts from "static/fonts/kinto"
Load template from "static/ogp/hoge.png" directory
WARN: "date, lastmod, publishDate" is not defined or empty
Success to generate twitter card into static/ogp/hoge.png
```
