### PR TITLE
Allow categories field to not be an array

### DIFF
--- a/pkg/hugo/frontmatter.go
+++ b/pkg/hugo/frontmatter.go
@@ -60,8 +60,14 @@ func parseFrontMatter(w io.Writer, r io.Reader, currentTime time.Time) (*FrontMa
 			return nil, err
 		}
 	}
-	if fm.Category, err = getFirstStringItem(&cfm, fmCategories); err != nil {
-		return nil, err
+	if isArray := isArray(&cfm, fmCategories); isArray {
+		if fm.Category, err = getFirstStringItem(&cfm, fmCategories); err != nil {
+			return nil, err
+		}	
+	} else {
+		if fm.Category, err = getString(&cfm, fmCategories); err != nil {
+			return nil, err
+		}
 	}
 	if fm.Tags, err = getAllStringItems(&cfm, fmTags); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adapts `pkg/hugo/frontmatter.go` to allow category/categories field to not be an array; uses the same approach taken with author field.

Fixes #27 