### PR TITLE
Add a limit to tags

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -174,7 +174,12 @@ func generateTCard(streams IOStreams, contentPath, outPath string, tpl image.Ima
 	}
 
 	var tags []string
-	for _, t := range fm.Tags {
+	lim := len(fm.Tags)
+	if l := *cnf.Tags.Limit; l > 0 && l <= lim {
+		lim = l
+	}
+
+	for _, t := range fm.Tags[0:lim] {
 		tags = append(tags, strings.Title(t))
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -175,11 +175,11 @@ func generateTCard(streams IOStreams, contentPath, outPath string, tpl image.Ima
 
 	var tags []string
 	lim := len(fm.Tags)
-	if l := *cnf.Tags.Limit; l > 0 && l <= lim {
+	if l := cnf.Tags.Limit; l > 0 && l <= lim {
 		lim = l
 	}
 
-	for _, t := range fm.Tags[0:lim] {
+	for _, t := range fm.Tags[:lim] {
 		tags = append(tags, strings.Title(t))
 	}
 

--- a/example/default.config.yaml
+++ b/example/default.config.yaml
@@ -28,6 +28,7 @@ info:
   timeFormat: "Jan 2"
 tags:
   enabled: true
+  limit: 0
   start:
     px: 1025
     py: 451

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type BoxTextsOption struct {
 	BoxSpacing *int      `json:"boxSpacing,omitempty"`
 	BoxAlign   box.Align `json:"boxAlign,omitempty"`
 	Enabled    *bool     `json:"enabled,omitempty"`
+	Limit      *int      `json:"limit,omitempty"`
 }
 
 type Point struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ type BoxTextsOption struct {
 	BoxSpacing *int      `json:"boxSpacing,omitempty"`
 	BoxAlign   box.Align `json:"boxAlign,omitempty"`
 	Enabled    *bool     `json:"enabled,omitempty"`
-	Limit      *int      `json:"limit,omitempty"`
+	Limit      int      `json:"limit,omitempty"`
 }
 
 type Point struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -36,6 +36,7 @@ var defaultCnf = DrawingConfig{
 	},
 	Tags: &BoxTextsOption{
 		Enabled:    ptrBool(true),
+		Limit:      ptrInt(0),
 		TextOption: TextOption{
 			Start:      &Point{X: 1025, Y: 451},
 			FgHexColor: "#FFFFFF",
@@ -101,6 +102,9 @@ func defaultTags(bto *BoxTextsOption) {
 	}
 	if bto.Enabled == nil {
 		bto.Enabled = defaultCnf.Tags.Enabled
+	}
+	if bto.Limit == nil {
+		bto.Limit = defaultCnf.Tags.Limit
 	}
 
 	setArgsAsDefaultTextOption(&bto.TextOption, &defaultCnf.Tags.TextOption)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -36,7 +36,7 @@ var defaultCnf = DrawingConfig{
 	},
 	Tags: &BoxTextsOption{
 		Enabled:    ptrBool(true),
-		Limit:      ptrInt(0),
+		Limit:      0,
 		TextOption: TextOption{
 			Start:      &Point{X: 1025, Y: 451},
 			FgHexColor: "#FFFFFF",
@@ -103,7 +103,7 @@ func defaultTags(bto *BoxTextsOption) {
 	if bto.Enabled == nil {
 		bto.Enabled = defaultCnf.Tags.Enabled
 	}
-	if bto.Limit == nil {
+	if bto.Limit < 0 {
 		bto.Limit = defaultCnf.Tags.Limit
 	}
 


### PR DESCRIPTION
Add an optional `Limit` field to the `Tags` section to limit the amount of tags being added to the cover.
Default value is `0` which means "all tags". Any value between 0 - [total amount of tags] will limit the tags being added.
Invalid values such as <0 or >[total amount of tags] will result in all tags being added.

Fix #29