### PR TITLE
Support `TitleCaseEnabled` option for tags

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -180,7 +180,10 @@ func generateTCard(streams IOStreams, contentPath, outPath string, tpl image.Ima
 	}
 
 	for _, t := range fm.Tags[:lim] {
-		tags = append(tags, strings.Title(t))
+		if *cnf.Tags.TitleCaseEnabled {
+			t = strings.Title(t)
+		}
+		tags = append(tags, t)
 	}
 
 	/* Title */

--- a/example/default.config.yaml
+++ b/example/default.config.yaml
@@ -29,6 +29,7 @@ info:
 tags:
   enabled: true
   limit: 0
+  titleCaseEnabled: true
   start:
     px: 1025
     py: 451

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,12 +32,13 @@ type MultiLineTextOption struct {
 
 type BoxTextsOption struct {
 	TextOption
-	BgHexColor string    `json:"bgHexColor,omitempty"`
-	BoxPadding *Padding  `json:"boxPadding,omitempty"`
-	BoxSpacing *int      `json:"boxSpacing,omitempty"`
-	BoxAlign   box.Align `json:"boxAlign,omitempty"`
-	Enabled    *bool     `json:"enabled,omitempty"`
-	Limit      int      `json:"limit,omitempty"`
+	BgHexColor       string    `json:"bgHexColor,omitempty"`
+	BoxPadding       *Padding  `json:"boxPadding,omitempty"`
+	BoxSpacing       *int      `json:"boxSpacing,omitempty"`
+	BoxAlign         box.Align `json:"boxAlign,omitempty"`
+	Enabled          *bool     `json:"enabled,omitempty"`
+	Limit            int       `json:"limit,omitempty"`
+	TitleCaseEnabled *bool     `json:"titleCaseEnabled,omitempty"`
 }
 
 type Point struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -35,8 +35,9 @@ var defaultCnf = DrawingConfig{
 		TimeFormat: "Jan 2",
 	},
 	Tags: &BoxTextsOption{
-		Enabled:    ptrBool(true),
-		Limit:      0,
+		Enabled:          ptrBool(true),
+		Limit:            0,
+		TitleCaseEnabled: ptrBool(true),
 		TextOption: TextOption{
 			Start:      &Point{X: 1025, Y: 451},
 			FgHexColor: "#FFFFFF",
@@ -106,6 +107,9 @@ func defaultTags(bto *BoxTextsOption) {
 	if bto.Limit < 0 {
 		bto.Limit = defaultCnf.Tags.Limit
 	}
+	if bto.TitleCaseEnabled == nil {
+		bto.TitleCaseEnabled = defaultCnf.Tags.TitleCaseEnabled
+	}
 
 	setArgsAsDefaultTextOption(&bto.TextOption, &defaultCnf.Tags.TextOption)
 
@@ -152,5 +156,5 @@ func ptrInt(x int) *int {
 }
 
 func ptrBool(b bool) *bool {
-    return &b
+	return &b
 }


### PR DESCRIPTION
By default, tcardgen converts all tags to title case.

I have added a TitleCaseEnabled option, allowing users to choose whether to convert tags to title case or not.

Since the default value is true, this change should not cause any regressions.

The following images were generated using the tags ['Hugo', 'tcardgen', 'OGP']:

- Title case applied (`titleCaseEnabled: true` or not set):
![tcardgenを使ってHugoでOGPを設定する](https://github.com/user-attachments/assets/2a84bfb1-9b6d-402a-a726-b7fb632c7b08)

- Title case not applied (`titleCaseEnabled: false`):
![tcardgenを使ってHugoでOGPを設定する](https://github.com/user-attachments/assets/b24592be-eb9d-43c3-bb53-75bd593a7ee1)


Fix #38 
