### PR TITLE
feat: add indicator for additional tags

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -186,6 +186,10 @@ func generateTCard(streams IOStreams, contentPath, outPath string, tpl image.Ima
 		tags = append(tags, t)
 	}
 
+	if len(fm.Tags) > lim && *cnf.Tags.MoreTags {
+		tags = append(tags, "More...")
+	}
+
 	/* Title */
 	if err := c.DrawTextAtPoint(
 		fm.Title,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type BoxTextsOption struct {
 	Enabled          *bool     `json:"enabled,omitempty"`
 	Limit            int       `json:"limit,omitempty"`
 	TitleCaseEnabled *bool     `json:"titleCaseEnabled,omitempty"`
+	MoreTags         *bool     `json:"moreTags,omitempty"`
 }
 
 type Point struct {

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -37,6 +37,7 @@ var defaultCnf = DrawingConfig{
 	Tags: &BoxTextsOption{
 		Enabled:          ptrBool(true),
 		Limit:            0,
+		MoreTags:         ptrBool(false),
 		TitleCaseEnabled: ptrBool(true),
 		TextOption: TextOption{
 			Start:      &Point{X: 1025, Y: 451},


### PR DESCRIPTION
This PR adds "More..." to the list of tags in the generated image when total number of tags exceeds the configured limit for tags. A new configuration option, `moreTags: <bool>` is added to the `tags` section of the configuration file, and it defaults to `false` to preserve the existing behavior. Users will have to opt-in to the new behavior by setting this configuration value to `true`, ensuring there's no change for users when they upgrade to a new release.

Closes #41.